### PR TITLE
feat: Add admin panel with RBAC and user management

### DIFF
--- a/app/(admin)/admin/_components/AdminHeader.tsx
+++ b/app/(admin)/admin/_components/AdminHeader.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { SignOutButton } from "@/components/sign-out-button";
+import type { AdminUser } from "@/lib/rbac";
+
+interface AdminHeaderProps {
+  user: AdminUser;
+}
+
+export function AdminHeader({ user }: AdminHeaderProps) {
+  return (
+    <header className="border-b bg-card/50 backdrop-blur-sm sticky top-0 z-50">
+      <div className="px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-8">
+            <Link href="/admin" className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">
+                <svg
+                  className="w-4 h-4 text-primary"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                  />
+                </svg>
+              </div>
+              <h1 className="text-xl font-bold">RFPs.ai</h1>
+            </Link>
+            <span className="text-xs font-medium px-2 py-1 rounded bg-destructive/10 text-destructive border border-destructive/20">
+              ADMIN
+            </span>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">
+                {user.name || user.email}
+              </span>
+              <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary font-medium">
+                admin
+              </span>
+            </div>
+            <SignOutButton />
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/app/(admin)/admin/_components/AdminShell.tsx
+++ b/app/(admin)/admin/_components/AdminShell.tsx
@@ -1,0 +1,20 @@
+import { AdminSidebar } from "./AdminSidebar";
+import { AdminHeader } from "./AdminHeader";
+import type { AdminUser } from "@/lib/rbac";
+
+interface AdminShellProps {
+  user: AdminUser;
+  children: React.ReactNode;
+}
+
+export function AdminShell({ user, children }: AdminShellProps) {
+  return (
+    <div className="min-h-screen bg-background">
+      <AdminHeader user={user} />
+      <div className="flex">
+        <AdminSidebar />
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin/_components/AdminSidebar.tsx
+++ b/app/(admin)/admin/_components/AdminSidebar.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  Home,
+  Users,
+  Database,
+  ScrollText,
+  ArrowLeft,
+  Shield,
+} from "lucide-react";
+
+const navItems = [
+  {
+    title: "Admin Home",
+    href: "/admin",
+    icon: Home,
+  },
+  {
+    title: "Users",
+    href: "/admin/users",
+    icon: Users,
+  },
+  {
+    title: "Data Sources",
+    href: "/admin/data-sources",
+    icon: Database,
+  },
+  {
+    title: "Logs",
+    href: "/admin/logs",
+    icon: ScrollText,
+  },
+];
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-64 border-r bg-card/50 min-h-[calc(100vh-4rem)]">
+      <div className="flex flex-col h-full">
+        {/* Header */}
+        <div className="p-4 border-b">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 rounded-lg bg-destructive/10 flex items-center justify-center">
+              <Shield className="w-4 h-4 text-destructive" />
+            </div>
+            <div>
+              <h2 className="font-semibold text-sm">Admin Panel</h2>
+              <p className="text-xs text-muted-foreground">System Management</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Navigation */}
+        <nav className="flex-1 p-4 space-y-1">
+          {navItems.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  "flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                )}
+              >
+                <item.icon className="h-4 w-4" />
+                {item.title}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* Footer - Back to App */}
+        <div className="p-4 border-t">
+          <Link
+            href="/dashboard"
+            className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to App
+          </Link>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/app/(admin)/admin/_components/ForbiddenPage.tsx
+++ b/app/(admin)/admin/_components/ForbiddenPage.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ShieldX, ArrowLeft } from "lucide-react";
+
+export function ForbiddenPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="text-center max-w-md">
+        <div className="w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center mx-auto mb-6">
+          <ShieldX className="w-8 h-8 text-destructive" />
+        </div>
+        <h1 className="text-3xl font-bold mb-2">Access Denied</h1>
+        <p className="text-muted-foreground mb-6">
+          You don't have permission to access the admin panel. This area is
+          restricted to administrators only.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link href="/dashboard">
+            <Button variant="default">
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Go to Dashboard
+            </Button>
+          </Link>
+          <Link href="/">
+            <Button variant="outline">Return Home</Button>
+          </Link>
+        </div>
+        <p className="text-xs text-muted-foreground mt-8">
+          If you believe this is an error, please contact your system
+          administrator.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin/data-sources/page.tsx
+++ b/app/(admin)/admin/data-sources/page.tsx
@@ -1,0 +1,188 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { db } from "@/lib/db";
+import { dataSources } from "@/lib/db/schema";
+import { desc } from "drizzle-orm";
+import { Database, AlertCircle, CheckCircle2, PauseCircle } from "lucide-react";
+
+function formatDate(date: Date | null): string {
+  if (!date) return "Never";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function getStatusBadge(status: string | null) {
+  switch (status) {
+    case "active":
+      return (
+        <Badge variant="default" className="bg-green-500/10 text-green-600 border-green-500/20">
+          <CheckCircle2 className="w-3 h-3 mr-1" />
+          Active
+        </Badge>
+      );
+    case "paused":
+      return (
+        <Badge variant="secondary" className="bg-yellow-500/10 text-yellow-600 border-yellow-500/20">
+          <PauseCircle className="w-3 h-3 mr-1" />
+          Paused
+        </Badge>
+      );
+    case "error":
+      return (
+        <Badge variant="destructive" className="bg-red-500/10 text-red-600 border-red-500/20">
+          <AlertCircle className="w-3 h-3 mr-1" />
+          Error
+        </Badge>
+      );
+    default:
+      return (
+        <Badge variant="outline">
+          {status || "Unknown"}
+        </Badge>
+      );
+  }
+}
+
+async function getDataSources() {
+  const sources = await db
+    .select()
+    .from(dataSources)
+    .orderBy(desc(dataSources.updatedAt))
+    .limit(50);
+
+  return sources;
+}
+
+export default async function DataSourcesPage() {
+  const sources = await getDataSources();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Data Sources</h1>
+        <p className="text-muted-foreground">
+          Monitor RFP crawler status and data ingestion
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Database className="h-5 w-5" />
+            All Data Sources
+          </CardTitle>
+          <CardDescription>
+            {sources.length} data source{sources.length !== 1 ? "s" : ""} configured
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {sources.length === 0 ? (
+            <div className="text-center py-12">
+              <Database className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-medium mb-2">No Data Sources</h3>
+              <p className="text-muted-foreground max-w-sm mx-auto">
+                No data sources have been configured yet. Data sources are used
+                to crawl RFP listings from government procurement sites.
+              </p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>URL</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Crawl</TableHead>
+                  <TableHead>Last Success</TableHead>
+                  <TableHead>Errors</TableHead>
+                  <TableHead>Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sources.map((source) => (
+                  <TableRow key={source.id}>
+                    <TableCell className="font-medium">{source.name}</TableCell>
+                    <TableCell className="max-w-[200px] truncate">
+                      <a
+                        href={source.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                      >
+                        {source.url}
+                      </a>
+                    </TableCell>
+                    <TableCell>{getStatusBadge(source.status)}</TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDate(source.lastCrawl)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDate(source.lastSuccess)}
+                    </TableCell>
+                    <TableCell>
+                      {(source.errorCount ?? 0) > 0 ? (
+                        <span className="text-red-600 font-medium">
+                          {source.errorCount}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDate(source.updatedAt)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Error Details Card - Show if any sources have errors */}
+      {sources.some((s) => s.errorMessage) && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-destructive">
+              <AlertCircle className="h-5 w-5" />
+              Error Details
+            </CardTitle>
+            <CardDescription>
+              Recent error messages from data sources
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {sources
+                .filter((s) => s.errorMessage)
+                .map((source) => (
+                  <div
+                    key={source.id}
+                    className="p-4 rounded-lg border border-destructive/20 bg-destructive/5"
+                  >
+                    <div className="font-medium text-sm mb-1">{source.name}</div>
+                    <p className="text-sm text-muted-foreground font-mono">
+                      {source.errorMessage}
+                    </p>
+                  </div>
+                ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/(admin)/admin/logs/page.tsx
+++ b/app/(admin)/admin/logs/page.tsx
@@ -1,0 +1,71 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollText, Clock } from "lucide-react";
+
+export default function LogsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">System Logs</h1>
+        <p className="text-muted-foreground">
+          View system activity and audit logs
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ScrollText className="h-5 w-5" />
+            Activity Logs
+          </CardTitle>
+          <CardDescription>
+            Track system events and user actions
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-12">
+            <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mx-auto mb-4">
+              <Clock className="h-8 w-8 text-muted-foreground" />
+            </div>
+            <h3 className="text-lg font-medium mb-2">Coming Soon</h3>
+            <p className="text-muted-foreground max-w-md mx-auto">
+              System logging functionality is planned for a future release. 
+              This will include user activity logs, crawler run history, 
+              and audit trails for administrative actions.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Planned Features Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Planned Features</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li className="flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+              User authentication events (login, logout, password changes)
+            </li>
+            <li className="flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+              Data source crawler run history and errors
+            </li>
+            <li className="flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+              Admin action audit trail (role changes, configuration updates)
+            </li>
+            <li className="flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+              API usage and rate limiting events
+            </li>
+            <li className="flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground" />
+              Search query analytics and patterns
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(admin)/admin/page.tsx
+++ b/app/(admin)/admin/page.tsx
@@ -1,0 +1,165 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { db } from "@/lib/db";
+import { user, dataSources, rfps, companies } from "@/lib/db/schema";
+import { count, eq } from "drizzle-orm";
+import { Users, Database, FileText, Building2 } from "lucide-react";
+
+async function getStats() {
+  const [
+    totalUsers,
+    adminUsers,
+    totalDataSources,
+    activeDataSources,
+    totalRfps,
+    totalCompanies,
+  ] = await Promise.all([
+    db.select({ count: count() }).from(user),
+    db.select({ count: count() }).from(user).where(eq(user.role, "admin")),
+    db.select({ count: count() }).from(dataSources),
+    db.select({ count: count() }).from(dataSources).where(eq(dataSources.status, "active")),
+    db.select({ count: count() }).from(rfps),
+    db.select({ count: count() }).from(companies),
+  ]);
+
+  return {
+    totalUsers: totalUsers[0]?.count ?? 0,
+    adminUsers: adminUsers[0]?.count ?? 0,
+    totalDataSources: totalDataSources[0]?.count ?? 0,
+    activeDataSources: activeDataSources[0]?.count ?? 0,
+    totalRfps: totalRfps[0]?.count ?? 0,
+    totalCompanies: totalCompanies[0]?.count ?? 0,
+  };
+}
+
+export default async function AdminHomePage() {
+  const stats = await getStats();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+        <p className="text-muted-foreground">
+          System overview and management
+        </p>
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Users</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.totalUsers}</div>
+            <p className="text-xs text-muted-foreground">
+              {stats.adminUsers} admin{stats.adminUsers !== 1 ? "s" : ""}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Data Sources</CardTitle>
+            <Database className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.totalDataSources}</div>
+            <p className="text-xs text-muted-foreground">
+              {stats.activeDataSources} active
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total RFPs</CardTitle>
+            <FileText className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.totalRfps}</div>
+            <p className="text-xs text-muted-foreground">
+              In database
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Companies</CardTitle>
+            <Building2 className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.totalCompanies}</div>
+            <p className="text-xs text-muted-foreground">
+              Registered profiles
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick Links */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Quick Actions</CardTitle>
+            <CardDescription>
+              Common administrative tasks
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <a
+              href="/admin/users"
+              className="block p-3 rounded-lg border hover:bg-muted transition-colors"
+            >
+              <div className="font-medium">Manage Users</div>
+              <p className="text-sm text-muted-foreground">
+                View users and manage roles
+              </p>
+            </a>
+            <a
+              href="/admin/data-sources"
+              className="block p-3 rounded-lg border hover:bg-muted transition-colors"
+            >
+              <div className="font-medium">Data Sources</div>
+              <p className="text-sm text-muted-foreground">
+                Monitor crawler status and errors
+              </p>
+            </a>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>System Status</CardTitle>
+            <CardDescription>
+              Current system health
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm">Database</span>
+                <span className="text-xs px-2 py-1 rounded-full bg-green-500/10 text-green-600 font-medium">
+                  Connected
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm">Authentication</span>
+                <span className="text-xs px-2 py-1 rounded-full bg-green-500/10 text-green-600 font-medium">
+                  Active
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm">Crawlers</span>
+                <span className="text-xs px-2 py-1 rounded-full bg-yellow-500/10 text-yellow-600 font-medium">
+                  {stats.activeDataSources > 0 ? "Running" : "Not configured"}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin/users/UserRoleButton.tsx
+++ b/app/(admin)/admin/users/UserRoleButton.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { updateUserRole, type UpdateRoleResult } from "./actions";
+import { Shield, ShieldOff, Loader2 } from "lucide-react";
+
+interface UserRoleButtonProps {
+  userId: string;
+  currentRole: "user" | "admin" | null;
+  isCurrentUser: boolean;
+}
+
+export function UserRoleButton({
+  userId,
+  currentRole,
+  isCurrentUser,
+}: UserRoleButtonProps) {
+  const [isPending, setIsPending] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const isAdmin = currentRole === "admin";
+  const newRole = isAdmin ? "user" : "admin";
+
+  async function handleClick() {
+    setIsPending(true);
+    setMessage(null);
+
+    try {
+      const result: UpdateRoleResult = await updateUserRole(userId, newRole);
+
+      if (result.success) {
+        setMessage({ type: "success", text: result.message });
+        // Clear success message after 3 seconds
+        setTimeout(() => setMessage(null), 3000);
+      } else {
+        setMessage({ type: "error", text: result.error });
+      }
+    } catch (error) {
+      setMessage({ type: "error", text: "An unexpected error occurred" });
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant={isAdmin ? "outline" : "default"}
+        size="sm"
+        onClick={handleClick}
+        disabled={isPending}
+        className="min-w-[100px]"
+      >
+        {isPending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : isAdmin ? (
+          <>
+            <ShieldOff className="h-4 w-4 mr-1" />
+            Demote
+          </>
+        ) : (
+          <>
+            <Shield className="h-4 w-4 mr-1" />
+            Promote
+          </>
+        )}
+      </Button>
+      {isCurrentUser && (
+        <span className="text-xs text-muted-foreground">(You)</span>
+      )}
+      {message && (
+        <span
+          className={`text-xs ${
+            message.type === "success" ? "text-green-600" : "text-red-600"
+          }`}
+        >
+          {message.text}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/app/(admin)/admin/users/actions.ts
+++ b/app/(admin)/admin/users/actions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema";
+import { eq, count, and, ne } from "drizzle-orm";
+import { requireAdmin } from "@/lib/rbac";
+
+export type UpdateRoleResult =
+  | { success: true; message: string }
+  | { success: false; error: string };
+
+/**
+ * Update a user's role (admin-only action)
+ * Includes guardrails:
+ * - Cannot remove your own admin role if you're the last admin
+ * - Only admins can call this
+ */
+export async function updateUserRole(
+  targetUserId: string,
+  newRole: "user" | "admin"
+): Promise<UpdateRoleResult> {
+  // Verify caller is admin
+  const result = await requireAdmin();
+  if ("forbidden" in result) {
+    return { success: false, error: "You do not have permission to perform this action" };
+  }
+
+  const { user: currentAdmin } = result;
+
+  // Prevent removing your own admin role if you're the last admin
+  if (targetUserId === currentAdmin.id && newRole === "user") {
+    // Check how many admins exist
+    const adminCount = await db
+      .select({ count: count() })
+      .from(user)
+      .where(eq(user.role, "admin"));
+
+    if ((adminCount[0]?.count ?? 0) <= 1) {
+      return {
+        success: false,
+        error: "Cannot remove admin role: You are the only administrator",
+      };
+    }
+  }
+
+  // Check target user exists
+  const targetUser = await db.query.user.findFirst({
+    where: eq(user.id, targetUserId),
+  });
+
+  if (!targetUser) {
+    return { success: false, error: "User not found" };
+  }
+
+  // Update the role
+  await db
+    .update(user)
+    .set({ role: newRole, updatedAt: new Date() })
+    .where(eq(user.id, targetUserId));
+
+  revalidatePath("/admin/users");
+
+  const action = newRole === "admin" ? "promoted to admin" : "demoted to user";
+  return { success: true, message: `${targetUser.email} has been ${action}` };
+}

--- a/app/(admin)/admin/users/page.tsx
+++ b/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,175 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema";
+import { desc } from "drizzle-orm";
+import { Users, Shield, User as UserIcon } from "lucide-react";
+import { requireAdmin } from "@/lib/rbac";
+import { UserRoleButton } from "./UserRoleButton";
+
+function formatDate(date: Date | null): string {
+  if (!date) return "N/A";
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function getRoleBadge(role: string | null) {
+  if (role === "admin") {
+    return (
+      <Badge variant="default" className="bg-primary">
+        <Shield className="w-3 h-3 mr-1" />
+        Admin
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="secondary">
+      <UserIcon className="w-3 h-3 mr-1" />
+      User
+    </Badge>
+  );
+}
+
+async function getUsers() {
+  const users = await db
+    .select({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      createdAt: user.createdAt,
+      emailVerified: user.emailVerified,
+    })
+    .from(user)
+    .orderBy(desc(user.createdAt))
+    .limit(50);
+
+  return users;
+}
+
+export default async function UsersPage() {
+  // Get current admin for highlighting
+  const adminResult = await requireAdmin();
+  if ("forbidden" in adminResult) {
+    return null; // Layout will handle this
+  }
+  const currentAdminId = adminResult.user.id;
+
+  const users = await getUsers();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">Users</h1>
+        <p className="text-muted-foreground">
+          Manage user accounts and roles
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            All Users
+          </CardTitle>
+          <CardDescription>
+            {users.length} user{users.length !== 1 ? "s" : ""} registered
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {users.length === 0 ? (
+            <div className="text-center py-12">
+              <Users className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-medium mb-2">No Users</h3>
+              <p className="text-muted-foreground max-w-sm mx-auto">
+                No users have registered yet.
+              </p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Verified</TableHead>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.map((u) => (
+                  <TableRow key={u.id}>
+                    <TableCell className="font-medium">
+                      {u.email}
+                      {u.id === currentAdminId && (
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          (You)
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>{u.name || "—"}</TableCell>
+                    <TableCell>{getRoleBadge(u.role)}</TableCell>
+                    <TableCell>
+                      {u.emailVerified ? (
+                        <Badge variant="outline" className="text-green-600 border-green-600/20">
+                          Verified
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-muted-foreground">
+                          Pending
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatDate(u.createdAt)}
+                    </TableCell>
+                    <TableCell>
+                      <UserRoleButton
+                        userId={u.id}
+                        currentRole={u.role}
+                        isCurrentUser={u.id === currentAdminId}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Info Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">About User Roles</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground space-y-2">
+          <p>
+            <strong>Admin:</strong> Can access the admin panel, manage users, and
+            view system data.
+          </p>
+          <p>
+            <strong>User:</strong> Standard user with access to RFP search and
+            company profile features.
+          </p>
+          <p className="text-yellow-600">
+            Note: You cannot remove your own admin role if you are the only
+            administrator.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,0 +1,20 @@
+import { requireAdmin } from "@/lib/rbac";
+import { AdminShell } from "./admin/_components/AdminShell";
+import { ForbiddenPage } from "./admin/_components/ForbiddenPage";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const result = await requireAdmin();
+
+  // Show 403 page if user is not admin
+  if ("forbidden" in result) {
+    return <ForbiddenPage />;
+  }
+
+  const { user } = result;
+
+  return <AdminShell user={user}>{children}</AdminShell>;
+}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -5,6 +5,9 @@ import { headers } from "next/headers";
 import { SignOutButton } from "@/components/sign-out-button";
 import { isPreviewDeployment } from "@/lib/preview";
 import { AppProviders } from "@/components/app-providers";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
 
 export default async function AppLayout({
   children,
@@ -33,7 +36,17 @@ export default async function AppLayout({
     redirect("/login");
   }
   
-  console.log("[Layout] Rendering with preview:", isPreview, "session:", !!session);
+  // Check if user is admin (only if we have a session)
+  let isAdmin = false;
+  if (session) {
+    const userRecord = await db.query.user.findFirst({
+      where: eq(user.id, session.user.id),
+      columns: { role: true },
+    });
+    isAdmin = userRecord?.role === "admin";
+  }
+  
+  console.log("[Layout] Rendering with preview:", isPreview, "session:", !!session, "isAdmin:", isAdmin);
 
   return (
     <div className="min-h-screen bg-background">
@@ -78,6 +91,14 @@ export default async function AppLayout({
                 >
                   Profile
                 </Link>
+                {isAdmin && (
+                  <Link
+                    href="/admin"
+                    className="text-sm font-medium text-destructive hover:text-destructive/80 transition-colors"
+                  >
+                    Admin
+                  </Link>
+                )}
               </div>
             </div>
             <div className="flex items-center gap-4">

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,0 +1,123 @@
+import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { user } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export type AdminUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  role: "user" | "admin" | null;
+  createdAt: Date;
+};
+
+export type AdminSession = {
+  session: NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>;
+  user: AdminUser;
+};
+
+/**
+ * Check if a user has admin role
+ */
+export function isAdmin(userRecord: { role: string | null } | null): boolean {
+  return userRecord?.role === "admin";
+}
+
+/**
+ * Get the current session and user with role info
+ * Returns null if no session exists
+ */
+export async function getAdminSession(): Promise<AdminSession | null> {
+  const headerList = await headers();
+  
+  const session = await auth.api.getSession({
+    headers: headerList,
+  });
+
+  if (!session) {
+    return null;
+  }
+
+  // Fetch the full user record with role from database
+  const userRecord = await db.query.user.findFirst({
+    where: eq(user.id, session.user.id),
+  });
+
+  if (!userRecord) {
+    return null;
+  }
+
+  return {
+    session,
+    user: {
+      id: userRecord.id,
+      email: userRecord.email,
+      name: userRecord.name,
+      role: userRecord.role,
+      createdAt: userRecord.createdAt,
+    },
+  };
+}
+
+/**
+ * Require admin access for a page/route
+ * Returns { session, user } if admin, otherwise:
+ * - Redirects to /login if no session
+ * - Returns { forbidden: true } if user is not admin
+ * 
+ * Usage in page:
+ * const result = await requireAdmin();
+ * if ('forbidden' in result) {
+ *   return <ForbiddenPage />;
+ * }
+ * const { session, user } = result;
+ */
+export async function requireAdmin(): Promise<AdminSession | { forbidden: true }> {
+  const headerList = await headers();
+  
+  const session = await auth.api.getSession({
+    headers: headerList,
+  });
+
+  // No session -> redirect to login
+  if (!session) {
+    redirect("/login");
+  }
+
+  // Fetch the full user record with role from database
+  const userRecord = await db.query.user.findFirst({
+    where: eq(user.id, session.user.id),
+  });
+
+  // User not found (shouldn't happen) -> redirect to login
+  if (!userRecord) {
+    redirect("/login");
+  }
+
+  // Check admin role
+  if (userRecord.role !== "admin") {
+    return { forbidden: true };
+  }
+
+  return {
+    session,
+    user: {
+      id: userRecord.id,
+      email: userRecord.email,
+      name: userRecord.name,
+      role: userRecord.role,
+      createdAt: userRecord.createdAt,
+    },
+  };
+}
+
+/**
+ * Check if current user is admin (for conditional rendering)
+ * Returns true if admin, false otherwise
+ */
+export async function checkIsAdmin(): Promise<boolean> {
+  const result = await getAdminSession();
+  return result !== null && isAdmin(result.user);
+}

--- a/scripts/promote-admin.ts
+++ b/scripts/promote-admin.ts
@@ -1,0 +1,94 @@
+/**
+ * Script to promote a user to admin role
+ *
+ * Usage:
+ *   npx tsx scripts/promote-admin.ts <email>
+ *
+ * Example:
+ *   npx tsx scripts/promote-admin.ts admin@example.com
+ *
+ * This script is for initial setup only. Once you have an admin,
+ * use the admin panel at /admin/users to manage roles.
+ */
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { eq } from "drizzle-orm";
+import { pgTable, text, timestamp, boolean, pgEnum } from "drizzle-orm/pg-core";
+
+// Minimal schema definition (to avoid importing full schema with env validation)
+const userRoleEnum = pgEnum("user_role", ["user", "admin"]);
+
+const user = pgTable("user", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull().unique(),
+  name: text("name"),
+  role: userRoleEnum("role").default("user"),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+});
+
+async function main() {
+  const email = process.argv[2];
+
+  if (!email) {
+    console.error("Usage: npx tsx scripts/promote-admin.ts <email>");
+    console.error("Example: npx tsx scripts/promote-admin.ts admin@example.com");
+    process.exit(1);
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    console.error("Error: DATABASE_URL environment variable is not set");
+    console.error("Set it in your .env file or export it:");
+    console.error("  export DATABASE_URL='postgresql://...'");
+    process.exit(1);
+  }
+
+  console.log(`Connecting to database...`);
+
+  const client = postgres(databaseUrl, { prepare: false });
+  const db = drizzle(client);
+
+  console.log(`Looking up user: ${email}`);
+
+  // Find user by email
+  const existingUser = await db
+    .select()
+    .from(user)
+    .where(eq(user.email, email))
+    .limit(1);
+
+  if (existingUser.length === 0) {
+    console.error(`Error: No user found with email "${email}"`);
+    console.error("Make sure the user has registered first.");
+    await client.end();
+    process.exit(1);
+  }
+
+  const targetUser = existingUser[0];
+
+  if (targetUser.role === "admin") {
+    console.log(`User "${email}" is already an admin.`);
+    await client.end();
+    process.exit(0);
+  }
+
+  console.log(`Promoting user to admin...`);
+
+  // Update role to admin
+  await db
+    .update(user)
+    .set({ role: "admin", updatedAt: new Date() })
+    .where(eq(user.id, targetUser.id));
+
+  console.log(`✅ Success! User "${email}" is now an admin.`);
+  console.log(`They can access the admin panel at /admin`);
+
+  await client.end();
+}
+
+main().catch((error) => {
+  console.error("Error:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
- Add admin route group at /admin with isolated layout

- Implement RBAC helper with requireAdmin() function

- Create admin shell UI with sidebar navigation

- Add admin pages: dashboard, users, data-sources, logs

- Add 403 Forbidden page for non-admin users

- Add Admin link to navbar for admin users

- Add promote-admin.ts script for initial setup

- Add shadcn/ui Table component